### PR TITLE
Update code to reflect removal of begin pinOCD parameter

### DIFF
--- a/examples/configEEPROM/configEEPROM.ino
+++ b/examples/configEEPROM/configEEPROM.ino
@@ -11,7 +11,9 @@ void setup() {
   // Use default SPI for communication with the Tli4970
   Tli4970CurrentSensor.begin();
   // Use custom SPI
-  //Tli4970CurrentSensor.begin(SPI2, (uint8_t)96u, (uint8_t)71u, (uint8_t)97u);
+  //Tli4970CurrentSensor.begin(SPI2, (uint8_t)96u, (uint8_t)97u);
+  // Set a OCD pin in addition to the begin() functions to enable it
+  // Tli4970CurrentSensor.setPinOCD((uint8_t)71u);
 }
 
 // the loop function runs over and over again forever

--- a/src/Tli4970.h
+++ b/src/Tli4970.h
@@ -62,7 +62,7 @@ public:
 
 	Tli4970(void);
 	void begin(void);
-	void begin(SPIClass &bus, uint8_t pinCS, uint8_t pinOCD, uint8_t pinDIO);
+	void begin(SPIClass &bus, uint8_t pinCS, uint8_t pinDIO);
 	void end(void);
 	
 	void setSPIClockDivider(uint8_t div);


### PR DESCRIPTION
https://github.com/Infineon/TLI4970-D050T4-Current-Sensor/commit/39685365ba74f0464fa70e4604c09476a9965832 removed the pinOCD parameter from the begin() definition, but did not remove it from the prototype. This caused compilation to fail:
```
arduino\libraries\TLI4970-D050T4-Current-Sensor\examples\configEEPROM\configEEPROM.ino: In function 'void setup()':

configEEPROM:14:61: error: no matching function for call to 'Tli4970::begin(SPIClass&, uint8_t, uint8_t)'

   Tli4970CurrentSensor.begin(SPI, (uint8_t)96u, (uint8_t)97u);

                                                             ^
```

Since https://github.com/Infineon/TLI4970-D050T4-Current-Sensor/commit/39685365ba74f0464fa70e4604c09476a9965832 results in a breaking change to the library API, I recommend bumping the major version on the next release, in accordance with the [semver specification](https://semver.org/).

Fixes https://github.com/Infineon/TLI4970-D050T4-Current-Sensor/issues/4

CC: @NathansLab