### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=It can measure currents from -50 A to 50 A with a resolution of 13 bit
 category=Sensors
 url=https://www.infineon.com/cms/de/product/sensor/magnetic-current-sensor/TLI4970050+2+GO+KIT/productType.html?productType=5546d4624e24005f014e6775c8e1700f
 architectures=*
-
+depends=OneWire


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format